### PR TITLE
+af-inet-6+ is not 23

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -7,6 +7,16 @@
 (include "uv-errno.h")
 
 ;; -----------------------------------------------------------------------------
+;; constants
+;; -----------------------------------------------------------------------------
+(constant (+af-unspec+ "AF_UNSPEC"))
+(constant (+af-unix+ "AF_UNIX"))
+(constant (+af-inet+ "AF_INET"))
+(constant (+af-inet-6+ "AF_INET6"))
+(constant (+sock-stream+ "SOCK_STREAM"))
+(constant (+ipproto-tcp+ "IPPROTO_TCP"))
+
+;; -----------------------------------------------------------------------------
 ;; type mappings
 ;; -----------------------------------------------------------------------------
 (ctype ssize-t "ssize_t")

--- a/util.lisp
+++ b/util.lisp
@@ -1,12 +1,5 @@
 (in-package :libuv)
 
-(defconstant +af-unspec+ 0)
-(defconstant +af-unix+ 1)
-(defconstant +af-inet+ 2)
-(defconstant +af-inet-6+ 23)
-(defconstant +sock-stream+ 1)
-(defconstant +ipproto-tcp+ 6)
-
 (defun errval (err)
   "Get an error constant value by its name keyword.
 


### PR DESCRIPTION
On my Linux AF_INET6 is 10.
```
(as:with-event-loop () 
  (as:dns-lookup "ipv6.google.com" 
                 (lambda (&rest args) (print args))
                 :event-cb #'describe
                 :family as:+af-unspec+))
#<cl-async:dns-error {100511DF53}>
  [condition]

Slots with :instance allocation:
  code  = -1
  msg   = "unsupported DNS family: 10"
```