### PR TITLE
Fix the include path for Darwin.

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -2,13 +2,7 @@
 
 (cc-flags #+windows "-Ic:/include/"
           #+windows "-Ic:/include/uv/"
-
-          ;; it would be better to use ...Cellar/libuv/*/include/ so as not to
-          ;; require a change for a version bump, but the arg parser doesn't
-          ;; let us have a space after -I, which the shell requires for the *
-          ;; expansion :-/
-          #+darwin "-I/usr/local/Cellar/libuv/1.7.5/include/"
-          #+darwin "-I/usr/local/Cellar/libuv/1.8.0/include/")
+          #+darwin "-I/usr/local/include/")
 
 (include "uv.h")
 (include "uv-errno.h")


### PR DESCRIPTION
Homebrew makes a symlink of `uv.h` at `/usr/local/include`, so it should be a better place to include for following further libuv updates.
Actually, cl-libuv and libraries depending on it don't work now with libuv 1.9.1, the current version Homebrew provides.