### PR TITLE
allow groveling on freebsd

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -2,7 +2,7 @@
 
 (cc-flags #+windows "-Ic:/include/"
           #+windows "-Ic:/include/uv/"
-          #+darwin "-I/usr/local/include/")
+          #+(or darwin freebsd) "-I/usr/local/include/")
 
 (include "uv.h")
 (include "uv-errno.h")


### PR DESCRIPTION
Compliation fails at groveling on FreeBSD since the include path is not specified. 

This patch sets the include path to the location libuv is installed to by default when installed from ports.