### PR TITLE
Do not explicitly include uv-errno.h

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -5,7 +5,6 @@
           #+(or darwin freebsd) "-I/usr/local/include/")
 
 (include "uv.h")
-(include "uv-errno.h")
 
 ;; -----------------------------------------------------------------------------
 ;; constants

--- a/scripts/win-error.i
+++ b/scripts/win-error.i
@@ -37,6 +37,5 @@
 #define UV_SIGNAL_PRIVATE_FIELDS
 #define UV_LOOP_PRIVATE_FIELDS
 
-%include "/usr/local/include/uv-errno.h"
 %include "/usr/local/include/uv.h"
 


### PR DESCRIPTION
In libuv 1.21 `uv-errno.h` was renamed to `uv/errno.h`.  It is always included by `uv.h`.

Fixes #14.