### PR TITLE
add /usr/local/include to search path for uv.h on OpenBSD

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -2,7 +2,7 @@
 
 (cc-flags #+windows "-Ic:/include/"
           #+windows "-Ic:/include/uv/"
-          #+(or darwin freebsd) "-I/usr/local/include/")
+          #+(or darwin freebsd openbsd) "-I/usr/local/include/")
 
 (include "uv.h")
 


### PR DESCRIPTION
OpenBSD doesn't add /usr/local/include to header search path by default so add
it explicitly.