### PR TITLE
compatibility patch for 'mlisp'

### DIFF
--- a/accessors.lisp
+++ b/accessors.lisp
@@ -21,12 +21,12 @@
   (let ((makers nil))
     (do-symbols (sym :libuv)
       (let ((str (string sym)))
-        (when (and (zerop (or (search "UV-" str) -1))
-                   (or (string= "-S" (subseq str (- (length str) 2)))
-                       (string= "-T" (subseq str (- (length str) 2)))))
+        (when (and (zerop (or (search "UV-" str :test 'string-equal) -1))
+                   (or (string-equal "-S" (subseq str (- (length str) 2)))
+                       (string-equal "-T" (subseq str (- (length str) 2)))))
           (push
-            `(progn (make-accessors ,sym))
-            makers))))
+           `(progn (make-accessors ,sym))
+           makers))))
     `(progn ,@makers)))
 
 (eval-when (:compile-toplevel :load-toplevel)

--- a/exports.lisp
+++ b/exports.lisp
@@ -16,6 +16,6 @@
 
 (eval-when (:compile-toplevel :load-toplevel)
   (do-symbols (sym :libuv)
-    (when (zerop (or (search "UV-" (string sym)) -1))
+    (when (zerop (or (search "UV-" (string sym) :test 'string-equal) -1))
       (export sym))))
 

--- a/wrapper.lisp
+++ b/wrapper.lisp
@@ -19,9 +19,14 @@
                           ((lower digit) (list* c #\- rest))
                           (t (cons c rest)))))
                ((lower-case-p c)
-                (helper (cdr lst) 'lower (cons (char-upcase c) rest)))
+                (helper (cdr lst)
+                        'lower
+                        (cons (case (readtable-case *readtable*)
+                                (:preserve c)
+                                (t (char-upcase c)))
+                              rest)))
                ((digit-char-p c)
-                (helper (cdr lst) 'digit 
+                (helper (cdr lst) 'digit
                         (case last
                           ((upper lower) (list* c #\- rest))
                           (t (cons c rest)))))
@@ -47,7 +52,7 @@
       (when (eq flag 'enumvalue)
         (setf fix ""))
       (process (intern (concatenate 'string fix (nreverse (helper (concatenate 'list (strip-prefix "uv_" name)) nil nil)) fix)
-        package)))))
+                       package)))))
 
 (defun version<= (str-version str-cmp)
   (declare (ignore str-version str-cmp))


### PR DESCRIPTION
This is a patch for making this library compatible with AllegroCL's [Modern Mode](https://franz.com/support/documentation/current/doc/case.htm#modern-mode-1). Please consider merging, thanks.