### PR TITLE
[feature] allow loading libuv lib from custom path.

### DIFF
--- a/cl-libuv-config.asd
+++ b/cl-libuv-config.asd
@@ -1,0 +1,10 @@
+(cl:eval-when (:load-toplevel :execute)
+  (asdf:operate 'asdf:load-op 'cffi-grovel))
+
+(asdf:defsystem cl-libuv-config
+  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
+  :license "MIT"
+  :version "0.1.6"
+  :description "Configure libuv to be used by cl-libuv."
+  :serial t
+  :components ((:file "config")))

--- a/config.lisp
+++ b/config.lisp
@@ -1,0 +1,16 @@
+(in-package :cl-user)
+
+(defpackage :cl-libuv/config
+  (:use :common-lisp)
+  (:export #:load-from-custom-path))
+
+(in-package :cl-libuv/config)
+
+(defmacro load-from-custom-path (path)
+  "Define the path where libuv is to be found:
+    (ql:quickload :cl-libuv/config)
+    (cl-libuv-config:load-from-custom-path \"/opt/local/lib/libuv.so\")
+    (ql:quickload :cl-libuv)"
+  `(progn
+     (cffi:define-foreign-library libuv (t ,path))
+     (cffi:use-foreign-library libuv)))


### PR DESCRIPTION
If you have libuv installed on other path (in my case using nixpkgs),
cl-libuv won't find the libraries.

This patch allows to load from a custom path.

```lisp
(ql:quickload :cl-libuv/config)
(cl-libuv-config:load-from-custom-path "/opt/local/lib/libuv.so")
(ql:quickload :cl-libuv)
```

Let me know if there is a better way.