### PR TITLE
Add cc-flags for Mac with Homebrew.

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -1,8 +1,15 @@
 (in-package :libuv)
 
+#.(when (uiop:getenv "HOMEBREW_PREFIX")
+    (pushnew :homebrew *features*)
+    (values))
+
 (cc-flags #+windows "-Ic:/include/"
           #+windows "-Ic:/include/uv/"
-          #+(or darwin freebsd openbsd) "-I/usr/local/include/")
+          #+(or darwin freebsd openbsd) "-I/usr/local/include/"
+          #+homebrew
+          #.(concatenate 'string "-I" (uiop:getenv "HOMEBREW_PREFIX") "/include/")
+          )
 
 (include "uv.h")
 


### PR DESCRIPTION
If libuv is installed with Homebrew, then it's in a directory under "HOMEBREW_PREFIX" and not in one of the locations previously considered.

This modification checks for the presence of the `HOMEBREW_PREFIX` environment variable, and if it's found, adds `"${HOMEBREW_PREFIX}/include/"` to the `cc-flags`.

Because grovel.lisp isn't evaluated, this requires some inelegant use of read-time evaluation.